### PR TITLE
Fix progress bar overflow in guide

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,8 +34,8 @@
 <body class="bg-slate-950 text-slate-100 min-h-screen flex flex-col items-center justify-center p-4">
 
     <div class="bg-slate-900 rounded-3xl shadow-xl p-6 sm:p-8 md:p-12 w-full max-w-2xl mx-auto border border-sky-900">
-        <div class="mb-8 w-full bg-slate-800 rounded-full h-2">
-            <div id="progress-bar" class="progress-bar bg-sky-400 h-full rounded-full w-0"></div>
+        <div class="mb-8 w-full bg-slate-800 rounded-full h-2 overflow-hidden">
+            <div id="progress-bar" class="progress-bar bg-sky-400 h-full rounded-full w-0 max-w-full"></div>
         </div>
         
         <div id="guide-content">


### PR DESCRIPTION
## Summary
- Prevent progress bar from spilling outside its container by clipping overflow and capping width

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5111196c08332b15cb302302f7fdb